### PR TITLE
Fix text in the wrong order 

### DIFF
--- a/lib/pdf2table.js
+++ b/lib/pdf2table.js
@@ -92,7 +92,7 @@ function parse (pdfBuffer, callback) {
 					var firstYvalue = texts[i].y;
 
 					for (var j = 0; j < texts.length; j++) {
-						if(texts[i] !=texts[j]) {
+						if(texts[i] !== texts[j]) {
 
 							var distance = Math.abs(texts[j].y - texts[i].y);
 							if(smallestYValue === null || distance < smallestYValue) {
@@ -114,7 +114,7 @@ function parse (pdfBuffer, callback) {
 		for (var p = 0; p < data.data.Pages.length; p++) {
 			var page = data.data.Pages[p];
 
-			var rows = []; // store Texts in rows
+			var rows = []; // store Texts and their x positions in rows
 
 			for (var t = 0; t < page.Texts.length; t++) {
 				var text = page.Texts[t];
@@ -128,7 +128,10 @@ function parse (pdfBuffer, callback) {
 
 						// only add value of T to data (which is the actual text):
 						for (var i = 0; i < text.R.length; i++) {
-							rows[r].data.push(decodeURIComponent(text.R[i].T));
+							rows[r].data.push({
+								text: decodeURIComponent(text.R[i].T),
+								x: text.x
+							});
 						};
 						foundRow = true;
 					}
@@ -142,7 +145,10 @@ function parse (pdfBuffer, callback) {
 
 					// add text to row:
 					for (var i = 0; i < text.R.length; i++) {
-						row.data.push(decodeURIComponent(text.R[i].T));
+						row.data.push({
+							text: decodeURIComponent(text.R[i].T),
+							x: text.x
+						});
 					};
 
 					// add row to rows:
@@ -150,6 +156,11 @@ function parse (pdfBuffer, callback) {
 				}
 
 			};
+
+			// sort each extracted row
+			for (var i = 0; i < rows.length; i++) {
+				rows[i].data.sort(comparer)
+			}
 
 			// add rows to pages:
 			myPages.push(rows);
@@ -160,8 +171,15 @@ function parse (pdfBuffer, callback) {
 
 		for (var p = 0; p < myPages.length; p++) {
 			for (var r = 0; r < myPages[p].length; r++) {
-				rows.push(myPages[p][r].data)
-			};
+				// now that each row is made of objects
+				// we need to extract the 'text' property from the object
+				var rowEntries = []
+				var row = myPages[p][r].data;
+				for (var i = 0; i < row.length; i++) {
+					rowEntries.push(row[i].text)
+				}
+				// now append the extracted and ordered text into the return rows.
+				rows.push(rowEntries);			};
 		};
 
 		// return callback:
@@ -171,7 +189,19 @@ function parse (pdfBuffer, callback) {
 	pdfParser.parseBuffer(pdfBuffer);
 }
 
-
+var comparer = function (a, b) {
+	/*
+		Compares two objects by their 'x' properties.
+	*/
+  if (a.x > b.x) {
+    return 1;
+  }
+  if (a.x < b.x) {
+    return -1;
+  }
+  // a must be equal to b
+  return 0;
+}
 
 exports.parse = parse;
 


### PR DESCRIPTION
As discussed in SamDecrock/pdf2table#2 
This change should order the extracted values from the table according to their `x` position.

There were no test cases that I could find so I tested it on the table found in this file: https://www.mcgill.ca/students/exams/files/students.exams/december_2016_final_exam_schedule_with_room_locationsd8.pdf and it worked!

Hope this is alright!